### PR TITLE
Add string truncator transformer

### DIFF
--- a/feature_reviser/__init__.py
+++ b/feature_reviser/__init__.py
@@ -17,4 +17,5 @@ from feature_reviser.transformer.string_transformer import (
     IPAddressEncoderTransformer,
     PhoneTransformer,
     StringSimilarityTransformer,
+    StringTruncatorTransformer,
 )

--- a/feature_reviser/__init__.py
+++ b/feature_reviser/__init__.py
@@ -18,5 +18,4 @@ from feature_reviser.transformer.string_transformer import (
     PhoneTransformer,
     StringSimilarityTransformer,
     StringSlicerTransformer,
-    StringTruncatorTransformer,
 )

--- a/feature_reviser/__init__.py
+++ b/feature_reviser/__init__.py
@@ -17,5 +17,6 @@ from feature_reviser.transformer.string_transformer import (
     IPAddressEncoderTransformer,
     PhoneTransformer,
     StringSimilarityTransformer,
+    StringSlicerTransformer,
     StringTruncatorTransformer,
 )

--- a/feature_reviser/transformer/string_transformer.py
+++ b/feature_reviser/transformer/string_transformer.py
@@ -281,46 +281,12 @@ class PhoneTransformer(BaseTransformer):
                 return float(error_value)
 
 
-class StringTruncatorTransformer(BaseTransformer):
-    """
-    Truncates each entry in a string column up to a specified number of characters.
-
-    Args:
-        feature (str): The feature which should be transformed.
-        n_chars (int): The number of characters to truncate (default = 1).
-    """
-
-    def __init__(
-        self,
-        feature: str,
-        n_chars: int = 1,
-    ) -> None:
-        self.feature = feature
-        self.n_chars = n_chars
-
-    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
-        """
-        Truncates a string feature up to a specified number of characters.
-
-        Args:
-            X (pandas.DataFrame): DataFrame to transform.
-
-        Returns:
-            pandas.DataFrame: Original dataframe with truncated strings in the feature.
-        """
-
-        X = check_X(X)
-
-        X[self.feature] = [x[: self.n_chars] for x in X[self.feature]]
-
-        return X
-
-
 class StringSlicerTransformer(BaseTransformer):
     """
     Slices all entries of specified string features using the `slice()` function.
 
-    Note: The arguments for the `slice()` function are passed as a tuple. This shares the python quirk of writing a tuple with a single argument with the trailing comma.
+    Note: The arguments for the `slice()` function are passed as a tuple. This shares
+    the python quirk of writing a tuple with a single argument with the trailing comma.
 
     Example:
         >>> from feature_reviser import StringSlicerTransformer

--- a/feature_reviser/transformer/string_transformer.py
+++ b/feature_reviser/transformer/string_transformer.py
@@ -318,37 +318,50 @@ class StringTruncatorTransformer(BaseTransformer):
 
 class StringSlicerTransformer(BaseTransformer):
     """
-    Applies the python `slice()` function on all entries of a string column.
+    Slices all entries of specified string features using the `slice()` function.
 
-    Note: `slice_args` must be a tuple. This shares the python quirk of writing a tuple with
-    a single argument with the trailing comma.
+    Note: The arguments for the `slice()` function are passed as a tuple. This shares the python quirk of writing a tuple with a single argument with the trailing comma.
+
+    Example:
+        >>> from feature_reviser import StringSlicerTransformer
+        >>> import pandas as pd
+        >>> X = pd.DataFrame({"foo": ["abc", "def", "ghi"], "bar": ["jkl", "mno", "pqr"]})
+        >>> transformer = StringSlicerTransformer([("foo", (0, 3, 2)), ("bar", (2,))])
+        >>> transformer.fit_transform(X).values
+        array([['ac', 'jk'],
+               ['df', 'mn'],
+               ['gi', 'pq']], dtype=object)
 
     Args:
-        feature (str): The feature which should be transformed.
-        slice_args (Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]]): The arguments to the `slice` function.
+        slice_args (List[Tuple[str, Tuple[int, int, int]]]): The arguments to the `slice` function, for each feature.
     """
 
     def __init__(
         self,
-        feature: str,
-        slice_args: Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]],
+        slice_args: List[
+            Tuple[
+                str,
+                Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]],
+            ]
+        ],
     ) -> None:
-        self.feature = feature
+        super().__init__()
         self.slice_args = slice_args
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """
-        Applies the `slice()` function on all strings of the `feature` column.
+        Slices the strings of specified features in the dataframe.
 
         Args:
             X (pandas.DataFrame): DataFrame to transform.
 
         Returns:
-            pandas.DataFrame: Original dataframe with sliced strings in the feature.
+            pandas.DataFrame: Original dataframe with sliced strings in specified features.
         """
 
         X = check_X(X)
 
-        X[self.feature] = [x[slice(*self.slice_args)] for x in X[self.feature]]
+        for feature, slice_arg in self.slice_args:
+            X[feature] = [x[slice(*slice_arg)] for x in X[feature]]
 
         return X

--- a/feature_reviser/transformer/string_transformer.py
+++ b/feature_reviser/transformer/string_transformer.py
@@ -333,12 +333,12 @@ class StringSlicerTransformer(BaseTransformer):
                ['gi', 'pq']], dtype=object)
 
     Args:
-        slice_args (List[Tuple[str, Tuple[int, int, int]]]): The arguments to the `slice` function, for each feature.
+        features (List[Tuple[str, Tuple[int, int, int]]]): The arguments to the `slice` function, for each feature.
     """
 
     def __init__(
         self,
-        slice_args: List[
+        features: List[
             Tuple[
                 str,
                 Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]],
@@ -346,7 +346,7 @@ class StringSlicerTransformer(BaseTransformer):
         ],
     ) -> None:
         super().__init__()
-        self.slice_args = slice_args
+        self.features = features
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """
@@ -361,7 +361,7 @@ class StringSlicerTransformer(BaseTransformer):
 
         X = check_X(X)
 
-        for feature, slice_arg in self.slice_args:
-            X[feature] = [x[slice(*slice_arg)] for x in X[feature]]
+        for feature, slice_args in self.features:
+            X[feature] = [x[slice(*slice_args)] for x in X[feature]]
 
         return X

--- a/feature_reviser/transformer/string_transformer.py
+++ b/feature_reviser/transformer/string_transformer.py
@@ -314,3 +314,41 @@ class StringTruncatorTransformer(BaseTransformer):
         X[self.feature] = [x[: self.n_chars] for x in X[self.feature]]
 
         return X
+
+
+class StringSlicerTransformer(BaseTransformer):
+    """
+    Applies the python `slice()` function on all entries of a string column.
+
+    Note: `slice_args` must be a tuple. This shares the python quirk of writing a tuple with
+    a single argument with the trailing comma.
+
+    Args:
+        feature (str): The feature which should be transformed.
+        slice_args (Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]]): The arguments to the `slice` function.
+    """
+
+    def __init__(
+        self,
+        feature: str,
+        slice_args: Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]],
+    ) -> None:
+        self.feature = feature
+        self.slice_args = slice_args
+
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        """
+        Applies the `slice()` function on all strings of the `feature` column.
+
+        Args:
+            X (pandas.DataFrame): DataFrame to transform.
+
+        Returns:
+            pandas.DataFrame: Original dataframe with sliced strings in the feature.
+        """
+
+        X = check_X(X)
+
+        X[self.feature] = [x[slice(*self.slice_args)] for x in X[self.feature]]
+
+        return X

--- a/feature_reviser/transformer/string_transformer.py
+++ b/feature_reviser/transformer/string_transformer.py
@@ -279,3 +279,38 @@ class PhoneTransformer(BaseTransformer):
                 return float(re.sub(r"(?<!^)[^0-9]", "", error_value))
             except:  # pylint: disable=W0702
                 return float(error_value)
+
+
+class StringTruncatorTransformer(BaseTransformer):
+    """
+    Truncates each entry in a string column up to a specified number of characters.
+
+    Args:
+        feature (str): The feature which should be transformed.
+        n_chars (int): The number of characters to truncate (default = 1).
+    """
+
+    def __init__(
+        self,
+        feature: str,
+        n_chars: int = 1,
+    ) -> None:
+        self.feature = feature
+        self.n_chars = n_chars
+
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        """
+        Truncates a string feature up to a specified number of characters.
+
+        Args:
+            X (pandas.DataFrame): DataFrame to transform.
+
+        Returns:
+            pandas.DataFrame: Original dataframe with truncated strings in the feature.
+        """
+
+        X = check_X(X)
+
+        X[self.feature] = [x[: self.n_chars] for x in X[self.feature]]
+
+        return X

--- a/tests/test_transformer/test_string_transformer.py
+++ b/tests/test_transformer/test_string_transformer.py
@@ -133,18 +133,45 @@ def test_string_truncator_transformer_in_pipeline(X_strings):
 
 
 def test_string_slicer_transformer_in_pipeline(X_strings):
-    pipeline = make_pipeline(StringSlicerTransformer("strings_2", (5, 15, 2)))
+    pipeline = make_pipeline(
+        StringSlicerTransformer(
+            [
+                ("email", (5,)),
+                ("strings_1", (8, 16)),
+                ("strings_2", (5, 15, 2)),
+            ]
+        )
+    )
     result = pipeline.fit_transform(X_strings)
-    expected = pd.Series(
-        [
-            "i_o__",
-            "i_nte",
-            "i  hr",
-            "i__it",
-            "",
-            "^*)+",
-        ]
+
+    expected = pd.DataFrame(
+        {
+            "email": [
+                "test@",
+                "test1",
+                "test_",
+                "test_",
+                "ttt@t",
+                "test_",
+            ],
+            "strings_1": [
+                "a_string",
+                "another_",
+                "a_third_",
+                "a_fourth",
+                "a_fifth_",
+                "a_sixth_",
+            ],
+            "strings_2": [
+                "i_o__",
+                "i_nte",
+                "i  hr",
+                "i__it",
+                "",
+                "^*)+",
+            ],
+        }
     )
 
     assert pipeline.steps[0][0] == "stringslicertransformer"
-    assert result["strings_2"].equals(expected)
+    assert result.equals(expected)

--- a/tests/test_transformer/test_string_transformer.py
+++ b/tests/test_transformer/test_string_transformer.py
@@ -9,6 +9,7 @@ from feature_reviser import (
     IPAddressEncoderTransformer,
     PhoneTransformer,
     StringSimilarityTransformer,
+    StringTruncatorTransformer,
 )
 
 # pylint: disable=missing-function-docstring, missing-class-docstring
@@ -110,3 +111,21 @@ def test_string_similarity_transformer_in_pipeline(X_strings):
     )
     assert np.array_equal(result["strings_1_strings_2_similarity"].values, expected)
     assert pipeline.steps[0][0] == "stringsimilaritytransformer"
+
+
+def test_string_truncator_transformer_in_pipeline(X_strings):
+    pipeline = make_pipeline(StringTruncatorTransformer("strings_2", 2))
+    result = pipeline.fit_transform(X_strings)
+    expected = pd.Series(
+        [
+            "th",
+            "th",
+            "th",
+            "th",
+            " ",
+            "!@",
+        ]
+    )
+
+    assert pipeline.steps[0][0] == "stringtruncatortransformer"
+    assert result["strings_2"].equals(expected)

--- a/tests/test_transformer/test_string_transformer.py
+++ b/tests/test_transformer/test_string_transformer.py
@@ -10,7 +10,6 @@ from feature_reviser import (
     PhoneTransformer,
     StringSimilarityTransformer,
     StringSlicerTransformer,
-    StringTruncatorTransformer,
 )
 
 # pylint: disable=missing-function-docstring, missing-class-docstring
@@ -112,24 +111,6 @@ def test_string_similarity_transformer_in_pipeline(X_strings):
     )
     assert np.array_equal(result["strings_1_strings_2_similarity"].values, expected)
     assert pipeline.steps[0][0] == "stringsimilaritytransformer"
-
-
-def test_string_truncator_transformer_in_pipeline(X_strings):
-    pipeline = make_pipeline(StringTruncatorTransformer("strings_2", 2))
-    result = pipeline.fit_transform(X_strings)
-    expected = pd.Series(
-        [
-            "th",
-            "th",
-            "th",
-            "th",
-            " ",
-            "!@",
-        ]
-    )
-
-    assert pipeline.steps[0][0] == "stringtruncatortransformer"
-    assert result["strings_2"].equals(expected)
 
 
 def test_string_slicer_transformer_in_pipeline(X_strings):

--- a/tests/test_transformer/test_string_transformer.py
+++ b/tests/test_transformer/test_string_transformer.py
@@ -9,6 +9,7 @@ from feature_reviser import (
     IPAddressEncoderTransformer,
     PhoneTransformer,
     StringSimilarityTransformer,
+    StringSlicerTransformer,
     StringTruncatorTransformer,
 )
 
@@ -128,4 +129,22 @@ def test_string_truncator_transformer_in_pipeline(X_strings):
     )
 
     assert pipeline.steps[0][0] == "stringtruncatortransformer"
+    assert result["strings_2"].equals(expected)
+
+
+def test_string_slicer_transformer_in_pipeline(X_strings):
+    pipeline = make_pipeline(StringSlicerTransformer("strings_2", (5, 15, 2)))
+    result = pipeline.fit_transform(X_strings)
+    expected = pd.Series(
+        [
+            "i_o__",
+            "i_nte",
+            "i  hr",
+            "i__it",
+            "",
+            "^*)+",
+        ]
+    )
+
+    assert pipeline.steps[0][0] == "stringslicertransformer"
     assert result["strings_2"].equals(expected)


### PR DESCRIPTION
This PR adds a new transformer. For a specified feature with string entries in a dataframe, this transformer truncates the strings up to a specified number of characters. For example, if

`X = pd.DataFrame({"feature": ["foo", "bar"]})`

this transformer returns the following dataframe with the default settings:

`X = pd.DataFrame({"feature": ["f", "b"]})`

If `n_chars` is set to `2`, then the following dataframe is returned:

`X = pd.DataFrame({"feature": ["fo", "ba"]})`.